### PR TITLE
wifischedule: Add `ignore_stations` parameter.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=wifischedule
 PKG_VERSION:=1
-PKG_RELEASE:=1
+PKG_RELEASE:=3
 PKG_LICENSE:=PRPL
 
 PKG_MAINTAINER:=Nils Koenig <openwrt@newk.it> 

--- a/README.md
+++ b/README.md
@@ -34,9 +34,9 @@ The button "Determine Modules Automatically" tries to make a best guess determin
 When un-/loading the modules, there is a certain number of retries (`module_load`) performed.
 
 The option "Force disabling wifi even if stations associated" does what it says - when activated it simply shuts down WiFi.
-When unchecked, its checked every `recheck_interval` minutes if there are still stations associated. Once the stations disconnect, WiFi is disabled.
+When unchecked, its checked every `recheck_interval` minutes if there are still stations associated. Once the stations disconnect, WiFi is disabled. To ignore associated stations add their MAC to `ignore_stations`.
 
-Please note, that the parameters `module_load` and `recheck_interval` are only accessible through uci.
+Please note, that the parameters `module_load`, `recheck_interval` and `ignore_stations` are only accessible through uci.
 
 ## UCI Configuration `wifi_schedule`
 UCI configuration file: `/etc/config/wifi_schedule`:
@@ -47,6 +47,7 @@ config global
         option enabled '0'
         option recheck_interval '10'
         option modules_retries '10'
+#       option ignore_stations 'AA:AA:AA:AA:AA:AA BB:BB:BB:BB:BB:BB'
 
 config entry 'Businesshours'
         option enabled '0'

--- a/net/etc/config/wifi_schedule
+++ b/net/etc/config/wifi_schedule
@@ -3,6 +3,7 @@ config global
         option enabled '0'
         option recheck_interval '10'
         option modules_retries '10'
+#       option ignore_stations 'AA:AA:AA:AA:AA:AA BB:BB:BB:BB:BB:BB'
 
 config entry 'Businesshours'
         option enabled '0'

--- a/net/usr/bin/wifi_schedule.sh
+++ b/net/usr/bin/wifi_schedule.sh
@@ -313,16 +313,21 @@ soft_disable_wifi()
         return 1
     fi
 
+    local ignore_stations=$(_get_uci_value_raw ${GLOBAL}.ignore_stations)
+    [ -n "${ignore_stations}" ] && _log "Ignoring station(s) ${ignore_stations}"
+
     # check if no stations are associated
     local _if
     for _if in $(_get_wireless_interfaces)
     do
-        output=$(${iwinfo} ${_if} assoclist)
-        if [[ "$output" != "No station connected" ]]
-        then
+        local stations=$(${iwinfo} ${_if} assoclist | grep -o -E '([[:xdigit:]]{1,2}:){5}[[:xdigit:]]{1,2}')
+        if [ -n "${ignore_stations}" ]; then
+            stations=$(echo "${stations}" | grep -vwi -E "${ignore_stations// /|}")
+        fi
+
+        if [ -n "${stations}" ]; then
             _disable_wifi=0
-            local stations=$(echo ${output}| grep -o -E '([[:xdigit:]]{1,2}:){5}[[:xdigit:]]{1,2}' | tr '\n' ' ')
-            _log "Station(s) ${stations}associated on ${_if}"
+            _log "Station(s) $(echo ${stations}) associated on ${_if}"
         fi
     done
 


### PR DESCRIPTION
Hi!

First thanks for this package it is really helpful.

I have added a simple way to ignore associated stations in the soft_disable_wifi function. I use this to turn the wifi off at night whether or not my Roomba is connected.

My goal is to get this change back into the openwrt/packages repo. Since you are the maintainer I thought it would best to get in touch with you first. :)

Also, I have no clou on how to build a package for OpenWRT though I'm pretty sure I didn't break anything, but maybe you can help me out with this?

I've also forked the openwrt/packages repo an added the commit there:
https://github.com/bedaes/packages/commit/8e451afe6840d6b805364a945860725f658c67e6

Do you have any thoughts on this?

Have a nice evening & best regards.
